### PR TITLE
Fixed edge case dependency issue with spec

### DIFF
--- a/test/integration/suite.bash
+++ b/test/integration/suite.bash
@@ -2,6 +2,8 @@
 
 function clone-repo() {
   git clone git@github.com:cloud-elements/hykes-spec.git build/tmp/hykes-spec
+  (cd build/tmp/hykes-spec && \
+    git checkout $(git describe --tags $(git rev-list --tags --max-count=1)))
 }
 
 function exists-repo() {


### PR DESCRIPTION
An issue arises, due to the continuous release approach of spec, in which potentially breaking changes could be picked up from master. Instead, we want to use the latest tag for each of the dependent projects instead.